### PR TITLE
Fix a bug in `set` function

### DIFF
--- a/src/TLc5940.cpp
+++ b/src/TLc5940.cpp
@@ -86,7 +86,7 @@ uint8_t Tlc5940::update(){
 }
 
 void Tlc5940::set(uint8_t channel, uint16_t value) {
-    byte index8 = (3 * 16 - 1) - channel;
+    byte index8 = (NUM_TLCS * 16 - 1) - channel;
     uint8_t *index12p = this->tlc_GSData + ((((uint16_t)index8) * 3) >> 1);
     if (index8 & 1) { // starts in the middle
                       // first 4 bits intact | 4 top bits of value


### PR DESCRIPTION
It was hardcoded with 3 TLCs causing a hardfault reset on ESP32. Check this line in [Paul's library](https://github.com/PaulStoffregen/Tlc5940/blob/54c4315c84201e731f6008276858defb560ad61e/Tlc5940.cpp#L273) to make sure it has a bud in this library.